### PR TITLE
fixed port number and start_webhook call

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,7 @@
 import logging
 from telegram.ext import Updater, CommandHandler, MessageHandler, Filters
 import os
-PORT = int(os.environ.get('PORT', 5000))
+PORT = int(os.environ.get('PORT', '8443'))
 
 # Enable logging
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
@@ -49,10 +49,12 @@ def main():
     dp.add_error_handler(error)
 
     # Start the Bot
-    updater.start_webhook(listen="0.0.0.0",
-                          port=int(PORT),
-                          url_path=TOKEN)
-    updater.bot.setWebhook('https://yourherokuappname.herokuapp.com/' + TOKEN)
+    updater.start_webhook(
+        listen="0.0.0.0",
+        port=int(PORT),
+        url_path=TOKEN,
+        webhook_url='https://yourherokuappname.herokuapp.com/' + TOKEN
+    )
 
     # Run the bot until you press Ctrl-C or the process receives SIGINT,
     # SIGTERM or SIGABRT. This should be used most of the time, since


### PR DESCRIPTION
This pull request fixes the ```start_webhook()``` call in the ```bot.py``` file by implementing the changes described in [this SO post](https://stackoverflow.com/questions/66711302/python-telegram-bot-i-already-port-8443-but-error-while-bootstrap-set-webhook-b).